### PR TITLE
Fix LED pin

### DIFF
--- a/code.py
+++ b/code.py
@@ -21,7 +21,7 @@ bt = digitalio.DigitalInOut(board.GP25)
 bt.direction = digitalio.Direction.INPUT
 bt.pull = digitalio.Pull.UP
 
-led = digitalio.DigitalInOut(board.GP24)
+led = digitalio.DigitalInOut(board.GP12)
 led.direction = digitalio.Direction.OUTPUT
 
 def get_substr(string, start, end):


### PR DESCRIPTION
Hi Tomislav,

Good job with the PicoUSB, it's a great little device, I already love it.

I noticed that the code uses pin 24 to drive the LED, but I found it was on pin 12 on my unit.
Unless there are multiple batches of PicoUSB with different LED pins, I think this small modification should brighten our jokes.